### PR TITLE
feat: make both apps available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,15 @@ node_js: "10"
 matrix:
   include:
     - osx_image: xcode7.3
-      env: BUILD_DIR=UICatalog/build CMD=install
     - osx_image: xcode8.3
-      env: BUILD_DIR=UICatalog/build CMD=install
     - osx_image: xcode9.4
-      env: BUILD_DIR=UICatalog/build CMD=install
     - osx_image: xcode10.2
-      env: BUILD_DIR=UICatalog/build CMD=install
     - osx_image: xcode11
-      env: BUILD_DIR=UIKitCatalog/build CMD=install:ios13
+install:
+  # do nothing, since the whole test is installation
+  - ":"
+before_script:
+  - rm -rf UICatalog/build
+  - rm -rf UIKitCatalog/build
 script:
-  - rm -rf ${BUILD_DIR}
-  - npm run ${CMD}
+  - npm run install

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_script:
   - rm -rf UICatalog/build
   - rm -rf UIKitCatalog/build
 script:
-  - npm run install
+  - npm install

--- a/README.md
+++ b/README.md
@@ -9,6 +9,49 @@ or the [docs for UIKitCatalog](./UIKitCatalog/uicatalog-info.md)
 UICatalog is for Xcode 10-
 UIKitCatalog is for Xcode 11+
 
+This package exposes the following:
+1. `uiCatalog`
+      a. `relative`
+          i. `iphoneos`: relative path to the real device app
+          ii. `iphonesimulator`: relative path to the simulator app
+      b. `absolute`
+          i. `iphoneos`: absolute path to the real device app
+          ii. `iphonesimulator`: absolute path to the simulator app
+1. `uiKitCatalog`
+      a. `relative`
+          i. `iphoneos`: relative path to the real device app
+          ii. `iphonesimulator`: relative path to the simulator app
+      b. `absolute`
+          i. `iphoneos`: absolute path to the real device app
+          ii. `iphonesimulator`: absolute path to the simulator app
+
+E.g.,
+```json
+{
+  "uiCatalog": {
+    "relative": {
+      "iphoneos": "UICatalog/build/Release-iphoneos/UICatalog-iphoneos.app",
+      "iphonesimulator": "UICatalog/build/Release-iphonesimulator/UICatalog-iphonesimulator.app"
+    },
+    "absolute": {
+      "iphoneos": "/node_modules/ios-uicatalog/UICatalog/build/Release-iphoneos/UICatalog-iphoneos.app",
+      "iphonesimulator": "/node_modules/ios-uicatalog/UICatalog/build/Release-iphonesimulator/UICatalog-iphonesimulator.app"
+    }
+  },
+  "uiKitCatalog": {
+    "relative": {
+      "iphoneos": "UIKitCatalog/build/Release-iphoneos/UIKitCatalog-iphoneos.app",
+      "iphonesimulator": "UIKitCatalog/build/Release-iphonesimulator/UIKitCatalog-iphonesimulator.app"
+    },
+    "absolute": {
+      "iphoneos": "/node_modules/ios-uicatalog/UIKitCatalog/build/Release-iphoneos/UIKitCatalog-iphoneos.app",
+      "iphonesimulator": "/node_modules/ios-uicatalog/UIKitCatalog/build/Release-iphonesimulator/UIKitCatalog-iphonesimulator.app"
+    }
+  }
+}
+```
+
+
 ### Building
 
 `npm install` will build the app for a simulator in `UICatalog/build` directory.
@@ -28,14 +71,10 @@ variable can be set to the path to an `xcconfig` file.
 UICatalog can work on iOS13, but it has issues such as xctest framework returns wrong coordinate.
 It is because UICatalog does not use newer framework APIs such as safeArea.
 
-Please use UIKitCatalog instead to work properly.
-It requres Xcode 11+.
+Please use UIKitCatalog instead to work properly. It will be built automatically
+during `npm install`, or by running `npm run build`.
 
-```
-npm run install:ios13
-```
-
-Then, apps will be generated in `UIKitCatalog/build` directory.
+Then, the apps will be in `UIKitCatalog/build` directory.
 
 
 ## Watch

--- a/UICatalog/gulpfile.js
+++ b/UICatalog/gulpfile.js
@@ -2,7 +2,8 @@
 
 const gulp = require('gulp');
 const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
-const { relative } = require('..');
+const path = require('path');
+const { uiCatalog } = require('..');
 
 
 boilerplate({
@@ -11,9 +12,16 @@ boilerplate({
   transpile: false,
   iosApps: {
     relativeLocations: {
-      iphoneos: relative.iphoneos,
-      iphonesimulator: relative.iphonesimulator,
+      iphoneos: path.resolve('..', uiCatalog.relative.iphoneos),
+      iphonesimulator: path.resolve('..', uiCatalog.relative.iphonesimulator),
     },
     appName: 'UICatalog.app',
   },
+});
+
+gulp.task('install', function (done) {
+  return gulp.series('ios-apps:install', (seriesDone) => {
+    seriesDone();
+    done();
+  })();
 });

--- a/UIKitCatalog/gulpfile.js
+++ b/UIKitCatalog/gulpfile.js
@@ -2,8 +2,13 @@
 
 const gulp = require('gulp');
 const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
-const { relative } = require('..');
+const path = require('path');
+const xcode = require('appium-xcode');
+const log = require('fancy-log');
+const { uiKitCatalog } = require('..');
 
+
+const appName = 'UIKitCatalog.app';
 
 boilerplate({
   build: 'ios-uicatalog',
@@ -11,9 +16,22 @@ boilerplate({
   transpile: false,
   iosApps: {
     relativeLocations: {
-      iphoneos: relative.iphoneos,
-      iphonesimulator: relative.iphonesimulator,
+      iphoneos: path.resolve('..', uiKitCatalog.relative.iphoneos),
+      iphonesimulator: path.resolve('..', uiKitCatalog.relative.iphonesimulator),
     },
-    appName: 'UIKitCatalog.app',
+    appName,
   },
+});
+
+
+gulp.task('install', async function (done) {
+  const xcodeVersion = await xcode.getVersion(true);
+  if (xcodeVersion.major < 11) {
+    log(`Not building ${appName} on Xcode version ${xcodeVersion.versionString}`);
+    return done();
+  }
+  return gulp.series('ios-apps:install', (seriesDone) => {
+    seriesDone();
+    done();
+  })();
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,3 +2,10 @@
 
 const gulp = require('gulp');
 const boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp);
+
+
+boilerplate({
+  build: 'ios-uicatalog',
+  projectRoot: __dirname,
+  transpile: false,
+});

--- a/index.js
+++ b/index.js
@@ -2,18 +2,31 @@
 
 const path = require('path');
 
-
-const relative = {
-  iphoneos: path.join('build', 'Release-iphoneos', 'UICatalog-iphoneos.app'),
-  iphonesimulator: path.join('build', 'Release-iphonesimulator', 'UICatalog-iphonesimulator.app'),
+const uiCatalog = {
+  relative: {
+    iphoneos: path.join('UICatalog', 'build', 'Release-iphoneos', 'UICatalog-iphoneos.app'),
+    iphonesimulator: path.join('UICatalog', 'build', 'Release-iphonesimulator', 'UICatalog-iphonesimulator.app'),
+  },
+  absolute: {
+    iphoneos: path.resolve(__dirname, 'UICatalog', 'build', 'Release-iphoneos', 'UICatalog-iphoneos.app'),
+    iphonesimulator: path.resolve(__dirname, 'UICatalog', 'build', 'Release-iphonesimulator', 'UICatalog-iphonesimulator.app'),
+  }
 };
 
-const absolute = {
-  iphoneos: path.resolve(__dirname, 'build', 'Release-iphoneos', 'UICatalog-iphoneos.app'),
-  iphonesimulator: path.resolve(__dirname, 'build', 'Release-iphonesimulator', 'UICatalog-iphonesimulator.app'),
+const uiKitCatalog = {
+  relative: {
+    iphoneos: path.join('UIKitCatalog', 'build', 'Release-iphoneos', 'UIKitCatalog-iphoneos.app'),
+    iphonesimulator: path.join('UIKitCatalog', 'build', 'Release-iphonesimulator', 'UIKitCatalog-iphonesimulator.app'),
+  },
+  absolute: {
+    iphoneos: path.resolve(__dirname, 'UIKitCatalog', 'build', 'Release-iphoneos', 'UIKitCatalog-iphoneos.app'),
+    iphonesimulator: path.resolve(__dirname, 'UIKitCatalog', 'build', 'Release-iphonesimulator', 'UIKitCatalog-iphonesimulator.app'),
+  }
 };
+
+
 
 module.exports = {
-  relative,
-  absolute,
+  uiCatalog,
+  uiKitCatalog,
 };

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "build": "cd UICatalog && gulp ios-apps:install",
-    "build:ios13": "cd UIKitCatalog && gulp ios-apps:install",
-    "install": "cd UICatalog && gulp ios-apps:install",
-    "install:ios13": "cd UIKitCatalog && gulp ios-apps:install",
+    "build": "npm run build:ios12 && npm run build:ios13",
+    "build:ios12": "cd UICatalog && gulp install",
+    "build:ios13": "cd UIKitCatalog && gulp install",
+    "install": "npm run build:ios12 && npm run build:ios13",
     "test": "gulp once",
     "watch": "gulp watch",
     "lint": "gulp lint",
@@ -50,12 +50,14 @@
   "author": "",
   "homepage": "https://github.com/appium/ios-uicatalog",
   "dependencies": {
-    "appium-gulp-plugins": "^4.0.0",
+    "appium-gulp-plugins": "^4.2.0",
+    "appium-xcode": "^3.9.0",
+    "fancy-log": "^1.3.3",
     "gulp": "^4.0.2"
   },
   "devDependencies": {
     "ajv": "^6.5.3",
-    "eslint-config-appium": "^4.0.1",
+    "eslint-config-appium": "^4.2.0",
     "pre-commit": "^1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npm run build:ios12 && npm run build:ios13",
     "build:ios12": "cd UICatalog && gulp install",
     "build:ios13": "cd UIKitCatalog && gulp install",
-    "install": "npm run build:ios12 && npm run build:ios13",
+    "prepare": "npm run build:ios12 && npm run build:ios13",
     "test": "gulp once",
     "watch": "gulp watch",
     "lint": "gulp lint",


### PR DESCRIPTION
Build both apps if possible, and export the paths so that they can be used in automated testing. 

This is a breaking change since the exports are different. 