### PR TITLE
fix: do not put xcuserdata into package

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,15 @@
     "UICatalog/uicatalog-info.md",
     "UICatalog/UICatalog",
     "UICatalog/UICatalog.xcodeproj",
+    "!UICatalog/UICatalog.xcodeproj/project.xcworkspace/xcuserdata",
+    "!UICatalog/UICatalog.xcodeproj/xcuserdata",
     "UIKitCatalog/gulpfile.js",
     "UIKitCatalog/uicatalog-info.md",
     "UIKitCatalog/Configuration",
     "UIKitCatalog/UIKitCatalog",
-    "UIKitCatalog/UIKitCatalog.xcodeproj"
+    "UIKitCatalog/UIKitCatalog.xcodeproj",
+    "!UIKitCatalog/UIKitCatalog.xcodeproj/project.xcworkspace/xcuserdata",
+    "!UIKitCatalog/UIKitCatalog.xcodeproj/xcuserdata"
   ],
   "author": "",
   "homepage": "https://github.com/appium/ios-uicatalog",


### PR DESCRIPTION
Get rid of `xcuserdata` from the npm package:
```
➜ npm pack --dry-run
npm notice
npm notice 📦  ios-uicatalog@3.6.0
npm notice === Tarball Details ===
npm notice name:          ios-uicatalog
npm notice version:       3.6.0
npm notice filename:      ios-uicatalog-3.6.0.tgz
npm notice package size:  9.5 MB
npm notice unpacked size: 10.6 MB
npm notice shasum:        331fd92f748c13c3a229f074db38317d5a999064
npm notice integrity:     sha512-muLKEC8jdUKgd[...]jvkortpbiwD8Q==
npm notice total files:   274
npm notice
ios-uicatalog-3.6.0.tgz
```

```
➜ npm pack --dry-run
npm notice
npm notice 📦  ios-uicatalog@3.6.0
npm notice === Tarball Details ===
npm notice name:          ios-uicatalog
npm notice version:       3.6.0
npm notice filename:      ios-uicatalog-3.6.0.tgz
npm notice package size:  9.4 MB
npm notice unpacked size: 10.5 MB
npm notice shasum:        f390dbce69f905f418e409820a464234fa164e9e
npm notice integrity:     sha512-mlOMgmun0B07P[...]H00/pJCoiAZ+A==
npm notice total files:   271
npm notice
ios-uicatalog-3.6.0.tgz
```